### PR TITLE
feat: add citeAs / citeWith properties

### DIFF
--- a/codemeta.jsonld
+++ b/codemeta.jsonld
@@ -20,6 +20,8 @@
       "applicationCategory": { "@id": "schema:applicationCategory"},
       "applicationSubCategory": { "@id": "schema:applicationSubCategory"},
       "citation": { "@id": "schema:citation"},
+      "citeAs": { "@id": "codemeta:citeAs", "@type": "@id"},
+      "citeWith": { "@id": "codemeta:citeWith", "@type": "@id"},
       "codeRepository": { "@id": "schema:codeRepository", "@type": "@id"},
       "contactPoint": { "@id": "schema:contactPoint" },
       "contactType": { "@id": "schema:contactType" },

--- a/examples/codemeta-software.json
+++ b/examples/codemeta-software.json
@@ -8,6 +8,8 @@
     "name": "Scott Peckham"
   },
   "citation": "Peckham; S. D. 'Geomorphometry and spatial hydrologic modelling.' Developments in Soil Science 33 (2009): 579-602.",
+  "citeAs": "https://doi.org/10.1594/IEDA/100174",
+  "citeWith": ["https://doi.org/10.1016/S0166-2481(08)00025-1"],
   "contributor": {
     "id": "https://w3id.org/okn/i/mint/bolton_bob",
     "type": "Person",
@@ -24,5 +26,5 @@
     "name": "Topoflow source code",
     "codemeta:codeRepository": "https://github.com/peckhams/topoflow"
   },
-  "referencePublication": "Peckham; S. D. 'Geomorphometry and spatial hydrologic modelling.' Developments in Soil Science 33 (2009): 579-602."
+  "referencePublication": "https://doi.org/10.1016/S0166-2481(08)00025-1"
 }

--- a/properties_description.csv
+++ b/properties_description.csv
@@ -20,10 +20,11 @@ schema:SoftwareApplication,softwareVersion,Text,Version of the software instance
 schema:SoftwareApplication,storageRequirements,Text or URL,Storage requirements (free space required).
 schema:SoftwareApplication,supportingData,DataFeed,Supporting data for a SoftwareApplication.
 schema:CreativeWork,author,Organization or Person,The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably.
-schema:CreativeWork,citation,CreativeWork or URL,"A citation or reference to another creative work, such as another publication, web page, scholarly article, etc."
+schema:CreativeWork,citation,CreativeWork or Text,"A general citation or reference to another creative work, such as another publication, web page, scholarly article. Use citeAs for citing specific software version and citeWith for companion works such as an origin or concept publication about the software."
 schema:CreativeWork,contributor,Organization or Person,A secondary contributor to the CreativeWork or Event.
 schema:CreativeWork,copyrightHolder,Organization or Person,The party holding the legal copyright to the CreativeWork.
 schema:CreativeWork,copyrightYear,Number,The year during which the claimed copyright for the CreativeWork was first asserted.
+schema:CreativeWork,creditText,Text,Human-readable displayable text used to credit person(s) or organization(s) associated with a published CreativeWork.
 schema:CreativeWork,dateCreated,Date,The date on which the CreativeWork was created or the item was added to a DataFeed.
 schema:CreativeWork,dateModified,Date,The date on which the CreativeWork was most recently modified or when the item's entry was modified within a DataFeed.
 schema:CreativeWork,datePublished,Date,Date of first broadcast/publication.
@@ -63,6 +64,8 @@ schema:Role,startDate,Date or Datetime,"The start date and time of the item, usu
 codemeta:SoftwareSourceCode,softwareSuggestions,SoftwareSourceCode,"Optional dependencies, e.g. for optional features, code development, etc."
 codemeta:SoftwareSourceCode,maintainer,Person,Individual responsible for maintaining the software (usually includes an email contact address)
 codemeta:SoftwareSourceCode,continuousIntegration,URL,A link to continuous integration service
+codemeta:SoftwareSourceCode,citeAs,URL,A permanent identifier to a specific citable version of the software
+codemeta:SoftwareSourceCode,citeWith,CreativeWork,Companion works that should be cited with the software
 codemeta:SoftwareSourceCode,buildInstructions,URL,A link to installation instructions/documentation
 codemeta:SoftwareSourceCode,developmentStatus,Text,"Description of development status, e.g. active, inactive, suspended. See repostatus.org"
 codemeta:SoftwareSourceCode,embargoEndDate,Date,"Software may be embargoed from public access until a specified date (e.g. pending publication, 1 year from publication)"


### PR DESCRIPTION
update example in codemeta-software.json to demonstrate usage as well as property descriptions

proposed semantics:

- citeAs: permanent identifier URL resolving to a landing page / specific version of this software (primary reference for this software)
- citeWith: List of permanent identifiers for companion works that the author(s) also want to be cited with this software (e.g., conceptual paper introducing the software, methods publications describing the algorithms or implementation)
- referencePublication: permanent identifier to the "conceptual publication" about the software
- citation: general related references and other citations as free Text (should deprecate?)

resolves https://github.com/codemeta/codemeta/issues/408
resolves https://github.com/codemeta/codemeta/issues/268
resolves https://github.com/codemeta/codemeta/issues/381